### PR TITLE
Add explicit app_label in models.py (steelscript.appfwk.apps.db.models.ExistingIntervals)

### DIFF
--- a/steelscript/appfwk/apps/db/models.py
+++ b/steelscript/appfwk/apps/db/models.py
@@ -10,6 +10,8 @@ from steelscript.appfwk.libs.fields import PickledObjectField
 
 
 class ExistingIntervals(models.Model):
+    class Meta:
+        app_label = 'steelscript.appfwk'
     """Store the existing time intervals in db for each table and
     a set of criteria fields (represented by the table_handle field).
     """


### PR DESCRIPTION
Hi  @mgarabed,  
I suggested this patch (explicit app_label) that fixes issue I got using appfwk 1.4 deployed on a Linux box.
Running "steel appfwk init" or starting progressd failed with the following errors:

```
Error while processing existing jobs:
/usr/lib/python2.7/site-packages/steelscript/appfwk/apps/db/models.py:12: RemovedInDjango19Warning: Model class steelscript.appfwk.apps.db.models.ExistingIntervals doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class ExistingIntervals(models.Model):
```

The patch run ok for me (testing plugins) but has unfortunately some side effects and would need some rework. It raises exceptions when going to admin -> admin panel.

```
LookupError at /admin/
No installed app with label 'steelscript.appfwk'.
Request Method:
GET
Request URL:
http://ssappfwkdev-j3ot5anlfcknu.westeurope.cloudapp.azure.com:8000/admin/
Django Version:
1.8.18
Exception Type:
LookupError
Exception Value:
No installed app with label 'steelscript.appfwk'.
Exception Location:
/usr/lib/python2.7/site-packages/django/apps/registry.py in get_app_config, line 150
Python Executable:
/bin/python
Python Version:
2.7.5
Python Path:
['/appfwk_project',
 '/',
 '/usr/lib/python2.7/site-packages/steelscript/appfwk',
 '/usr/lib64/python27.zip',
 '/usr/lib64/python2.7',
 '/usr/lib64/python2.7/plat-linux2',
 '/usr/lib64/python2.7/lib-tk',
 '/usr/lib64/python2.7/lib-old',
 '/usr/lib64/python2.7/lib-dynload',
 '/usr/lib64/python2.7/site-packages',
 '/usr/lib64/python2.7/site-packages/gtk-2.0',
 '/usr/lib/python2.7/site-packages']
Server time:
Sat, 10 Jun 2017 18:20:21 -0400
```
